### PR TITLE
[nbt-client-66] Show roster option in Faction Tools dropdown at all times

### DIFF
--- a/automation/fragment/navbar.html
+++ b/automation/fragment/navbar.html
@@ -39,7 +39,7 @@
                     <ul class="dropdown-menu">
                         <li ng-show="faction.status==='Pending'"><a class="ui-interactive nbt-menu-item" data-cmdTarget="cmdPlanetSetup">Faction Setup</a></li>
                         <li ng-show="faction.status==='Active' || faction.status==='Semi-Active'"><a class="ui-interactive nbt-menu-item" data-toggle="modal" data-target="#battlesModal">Battles</a></li>
-                        <li ng-show="faction.status==='Active' || faction.status==='Semi-Active'"><a class="ui-interactive nbt-menu-item" data-toggle="modal" data-target="#rosterModal">Roster</a></li>
+                        <li><a class="ui-interactive nbt-menu-item" data-toggle="modal" data-target="#rosterModal">Roster</a></li>
                     </ul>
                 </li>
 


### PR DESCRIPTION
Should be visible whenever that menu is visible (make it possible for factions to set up their roster prior to going active)