### PR TITLE
implement the zero-differential theft selection interface

### DIFF
--- a/automation/fragment/tracker.html
+++ b/automation/fragment/tracker.html
@@ -302,6 +302,17 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="row" ng-show="battle.combatUnitTheft.classes">
+                            <!-- classes to choose from -->
+                            <div class="col-md-4">
+                                <h5 class="nbt-h5">Combat Unit Classes</h5>
+                                <div style="height: 240px; overflow-y: auto; border: solid 1px #990000; padding: 8px">
+                                    <div ng-repeat="class in battle.combatUnitTheft.classes">
+                                        <input type="radio" ng-model="battle.combatUnitTheft.selectedClass" value="{{class}}">{{class}}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
 
                     <div ng-show="battle._links.repairs">

--- a/automation/js/nbt/controller/tracker.js
+++ b/automation/js/nbt/controller/tracker.js
@@ -688,7 +688,8 @@
 
             $scope.commitEffects = function() {
                 var theft = {
-                    instances: $scope.stolenUnits
+                    instances: $scope.stolenUnits,
+                    selectedClass: $scope.battle.combatUnitTheft.selectedClass
                 };
 
                 nbtBattle.commitEffects($scope.battle, theft, nbtIdentity.get().token, function(aData) {


### PR DESCRIPTION
Was missing the interface for zero-effective-differential theft selection -- should just offer whatever classes the backend lists, and the user chooses one of those, and the backend makes random selection from that.